### PR TITLE
BUG: fix #93

### DIFF
--- a/enigma-js/src/Enigma.js
+++ b/enigma-js/src/Enigma.js
@@ -447,7 +447,7 @@ export default class Enigma {
             resolve(response);
           });
         });
-        if (getTaskResultResult) {
+        if (getTaskResultResult.result) {
           switch (getTaskResultResult.result.status) {
             case 'SUCCESS':
               task.delta = getTaskResultResult.result.delta;

--- a/enigma-js/src/Server.js
+++ b/enigma-js/src/Server.js
@@ -100,7 +100,9 @@ export default class RPCServer {
               break;
             case (1):
               _counter++;
-              callback(null, null);
+              callback(null, {
+                result: null
+              });
               break;
             case (2):
               _counter++;


### PR DESCRIPTION
Adjustment to #93, where the double result object caused confusion. This is the proper way to do it, that passes both local unit tests and the integration tests.