### PR TITLE
BLD: advance epoch to the start

### DIFF
--- a/enigma-js/test/integrationTests/template.01_init.js
+++ b/enigma-js/test/integrationTests/template.01_init.js
@@ -1,4 +1,7 @@
 /* eslint-disable require-jsdoc */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import dotenv from 'dotenv';
 import forge from 'node-forge';
 import Web3 from 'web3';
@@ -50,10 +53,17 @@ describe('Init tests', () => {
     });
   });
 
+  const homedir = os.homedir();
   it('initializes Sample contract', async () => {
     sampleContract = new enigma.web3.eth.Contract(SampleContract['abi'],
       SampleContract.networks['4447'].address);
     expect(sampleContract.options.address).toBeTruthy;
+
+    fs.writeFile(path.join(homedir, '.enigma', 'addr-sample.txt'), sampleContract.options.address, 'utf8', function(err) {
+      if(err) {
+        return console.log(err);
+      }
+    });
   });
 
   it('should distribute ENG tokens', async () => {


### PR DESCRIPTION
Adjusted the `template.90_advance_epoch.js` so that instead of advancing a fixed `epochSize` number of blocks, it dynamically advances only the minimum number of blocks remaining to get to the start of the next Epoch. 

The purpose of this utility is just to avoid deploying a task towards the end of an epoch, and avoid the epoch transition.