### PR TITLE
MAINT: miscellaneous adjustments to integration tests

### DIFF
--- a/enigma-js/test/integrationTests/template.20_execute_fail_outofgas.js
+++ b/enigma-js/test/integrationTests/template.20_execute_fail_outofgas.js
@@ -81,16 +81,19 @@ describe('Enigma tests', () => {
   }, 10000);
 
   it('should get the failed result', async () => {
-    task = await new Promise((resolve, reject) => {
-        enigma.getTaskResult(task)
-          .on(eeConstants.GET_TASK_RESULT_RESULT, (result) => resolve(result))
-          .on(eeConstants.ERROR, (error) => reject(error));
-    });
+    do {
+      await sleep(1000);
+      task = await new Promise((resolve, reject) => {
+          enigma.getTaskResult(task)
+            .on(eeConstants.GET_TASK_RESULT_RESULT, (result) => resolve(result))
+            .on(eeConstants.ERROR, (error) => reject(error));
+      });
+    } while(!task.engStatus);
     expect(task.engStatus).toEqual('FAILED');
     expect(task.encryptedAbiEncodedOutputs).toBeTruthy();
     expect(task.workerTaskSig).toBeTruthy();
     task = await enigma.decryptTaskResult(task);
-    console.log('Output is: '+task.decryptedOutput);
+    console.log('Output is: ' + task.decryptedOutput);
   });
 
 });

--- a/enigma-js/test/integrationTests/template.20_execute_fail_wrong_encryption_key.js
+++ b/enigma-js/test/integrationTests/template.20_execute_fail_wrong_encryption_key.js
@@ -161,7 +161,6 @@ describe('Enigma tests', () => {
         .on(eeConstants.GET_TASK_RESULT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-    console.log('TASK', task);
     expect(task.engStatus).toEqual('FAILED');
     expect(task.encryptedAbiEncodedOutputs).toBeTruthy();
     expect(task.workerTaskSig).toBeTruthy();

--- a/enigma-js/test/integrationTests/testList.template.txt
+++ b/enigma-js/test/integrationTests/testList.template.txt
@@ -2,12 +2,16 @@
 02_deploy_calculator.spec.js
 02_deploy_erc20.spec.js
 02_deploy_flipcoin.spec.js
+90_advance_epoch.spec.js
 02_deploy_millionaire.spec.js
 03_deploy_fail_bytecode.spec.js
 03_deploy_fail_outofgas.spec.js
+90_advance_epoch.spec.js
 03_deploy_fail_parameters.spec.js
+03_deploy_fail_wrong_encryption_key.spec.js
 10_execute_flipcoin.spec.js
 10_execute_millionaire.spec.js
 10_execute_erc20.spec.js
 20_execute_fail_outofgas.spec.js
 20_execute_fail_parameters.spec.js
+20_execute_fail_wrong_encryption_key.spec.js


### PR DESCRIPTION
Various small adjustments to the integration tests:
- `template.20_execute_fail_outofgas.js` added a loop to allow for the results to propagate across the network. When running this test with multiple nodes, the client can be faster in checking for the result that what it takes for the result to propagate across the `p2p` network
- `template.20_execute_fail_wrong_encryption_key.js` removed unnecessary debug statement
- `testList.template.txt` added additional integration tests that are now always passing

Ready to merge