### PR TITLE
BLD: adjusting integration tests

### DIFF
--- a/enigma-js/test/integrationTests/template.03_deploy_fail_parameters.js
+++ b/enigma-js/test/integrationTests/template.03_deploy_fail_parameters.js
@@ -43,12 +43,12 @@ describe('Enigma tests', () => {
   let scTask2;
   it('should deploy secret contract', async () => {
     let scTaskFn = 'construct()';
-    let scTaskArgs =  '';   // Wrong parameters, expecting owner address and token supply
+    let scTaskArgs =  '';   // Wrong parameters, expecting ETH address
     let scTaskGasLimit = 1000000;
     let scTaskGasPx = utils.toGrains(1);
     let preCode;
     try {
-      preCode = fs.readFileSync(path.resolve(__dirname,'secretContracts/erc20.wasm'));
+      preCode = fs.readFileSync(path.resolve(__dirname,'secretContracts/voting.wasm'));
       preCode = preCode.toString('hex');
     } catch(e) {
       console.log('Error:', e.stack);
@@ -58,7 +58,8 @@ describe('Enigma tests', () => {
         .on(eeConstants.DEPLOY_SECRET_CONTRACT_RESULT, (receipt) => resolve(receipt))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, 30000);
+
   it('should get the failed receipt', async () => {
     do {
       await sleep(1000);
@@ -67,7 +68,7 @@ describe('Enigma tests', () => {
     } while (scTask2.ethStatus != 3);
     expect(scTask2.ethStatus).toEqual(3);
     process.stdout.write('Completed. Final Task Status is '+scTask2.ethStatus+'\n');
-  }, 10000);
+  }, 30000);
 
   it('should fail to verify deployed contract', async () => {
     const result = await enigma.admin.isDeployed(scTask2.scAddr);

--- a/enigma-js/test/integrationTests/testList.template.txt
+++ b/enigma-js/test/integrationTests/testList.template.txt
@@ -6,9 +6,11 @@
 02_deploy_voting.spec.js
 03_deploy_fail_bytecode.spec.js
 03_deploy_fail_outofgas.spec.js
+90_advance_epoch.spec.js
 03_deploy_fail_parameters.spec.js
 03_deploy_fail_wrong_encryption_key.spec.js
 03_deploy_fail_wrong_eth_address.spec.js
+90_advance_epoch.spec.js
 10_execute_calculator.spec.js
 10_execute_flipcoin.spec.js
 10_execute_millionaire.spec.js


### PR DESCRIPTION
- Changes `template.03_deploy_fail_parameters.js` to fail against voting contract instead of erc20 contract that has other challenges.
- Introduces manual advance_epoch temporarily while the issue is being solved elsewhere, to have integration tests pass reliably where they should