### PR TITLE
MAINT: tagging docker images depending on branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,5 @@ deploy:
   provider: script
   script: bash scripts/deploy.sh
   on:
-    branch: develop
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^master|develop$

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 git clone https://github.com/enigmampc/discovery-docker-network.git
 cd discovery-docker-network/enigma-contract
-docker build --build-arg GIT_BRANCH_CONTRACT=$TRAVIS_BRANCH -t enigmampc/enigma_contract:latest --no-cache .
+
+if [[ ${TRAVIS_BRANCH} == "master" ]]; then
+	TAG=latest
+else
+	# ${TRAVIS_BRANCH} == "develop"
+	TAG=develop
+fi
+
+docker build --build-arg GIT_BRANCH_CONTRACT=$TRAVIS_BRANCH -t enigmampc/enigma_contract:${TAG} --no-cache .
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push enigmampc/enigma_contract:latest
+
+docker push enigmampc/enigma_contract:${TAG}


### PR DESCRIPTION
This PR exercises caution in pushing docker images to DockerHub acknowledging that other developers now depend on those images for secret contract development through the [discovery-cli](https://github.com/enigmampc/discovery-cli) repo, and we don't want to inadvertently break those images even temporarily. Thus, the deploy script will now be run when new commits are pushed to both `develop` and `master` branches, with tagging images differently depending on the branch:
- commits to `master` tag the images `latest`, which are the ones that `discovery-cli` uses, and thus are deemed stable
- commits to `develop` tag the images `develop`, which will give us more flexibility developing new code.