### PR TITLE
BUG: fix deltaHashIndex

### DIFF
--- a/contracts/impl/EnigmaEvents.sol
+++ b/contracts/impl/EnigmaEvents.sol
@@ -17,7 +17,7 @@ contract EnigmaEvents {
     event TaskRecordsCreated(bytes32[] taskIds, bytes32[] inputsHashes, uint[] gasLimits, uint[] gasPxs, address sender,
         uint blockNumber);
     event ReceiptVerified(bytes32 taskId, bytes32 stateDeltaHash, bytes32 outputHash, bytes32 scAddr, uint gasUsed,
-        uint hashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
+        uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptFailed(bytes32 taskId, bytes sig);

--- a/contracts/impl/TaskImpl.sol
+++ b/contracts/impl/TaskImpl.sol
@@ -29,7 +29,7 @@ library TaskImpl {
         uint blockNumber);
     event SecretContractDeployed(bytes32 scAddr, bytes32 codeHash, bytes32 initStateDeltaHash);
     event ReceiptVerified(bytes32 taskId, bytes32 stateDeltaHash, bytes32 outputHash, bytes32 scAddr, uint gasUsed,
-        uint hashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
+        uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptFailed(bytes32 taskId, bytes sig);

--- a/contracts/impl/TaskImplSimulation.sol
+++ b/contracts/impl/TaskImplSimulation.sol
@@ -29,7 +29,7 @@ library TaskImplSimulation {
         uint blockNumber);
     event SecretContractDeployed(bytes32 scAddr, bytes32 codeHash, bytes32 initStateDeltaHash);
     event ReceiptVerified(bytes32 taskId, bytes32 stateDeltaHash, bytes32 outputHash, bytes32 scAddr, uint gasUsed,
-        uint hashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
+        uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptFailed(bytes32 taskId, bytes sig);


### PR DESCRIPTION
Fixes #56 for good. The delta indices were already included, but there was a mismatch of the name of the parameters. Matching now what P2P expects [here](https://github.com/enigmampc/enigma-p2p/blob/748b7cb289960479d702c0cfc82359f41b176819/src/ethereum/EnigmaContractReaderAPI.js#L412)