### PR TITLE
BLD: small updates

### DIFF
--- a/contracts/Enigma.sol
+++ b/contracts/Enigma.sol
@@ -371,37 +371,6 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     }
 
     /**
-   * Commit the computation task results on chain by first verifying the receipts and then the worker's signature.
-   * The task records are finalized and the worker is credited with the tasks' fees.
-   *
-   * @param _scAddr Secret contract address
-   * @param _taskIds Unique taskId
-   * @param _stateDeltaHashes Input state delta hashes
-   * @param _outputHashes Output state hashes
-   * @param _optionalEthereumData Output state hashes
-   * @param _optionalEthereumContractAddress Output state hashes
-   * @param _gasesUsed Output state hashes
-   * @param _sig Worker's signature
-   */
-    function commitReceipts(
-        bytes32 _scAddr,
-        bytes32[] memory _taskIds,
-        bytes32[] memory _stateDeltaHashes,
-        bytes32[] memory _outputHashes,
-        bytes memory _optionalEthereumData,
-        address _optionalEthereumContractAddress,
-        uint64[] memory _gasesUsed,
-        bytes memory _sig
-    )
-    public
-    workerLoggedIn(msg.sender)
-    contractDeployed(_scAddr)
-    {
-        TaskImpl.commitReceiptsImpl(state, _scAddr, _taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-            _optionalEthereumContractAddress, _gasesUsed, _sig);
-    }
-
-    /**
     * Commit the computation task failure on chain - the task fee is transfered to the worker and the status is
     * updated to indicate task failure.
     *

--- a/contracts/EnigmaSimulation.sol
+++ b/contracts/EnigmaSimulation.sol
@@ -371,37 +371,6 @@ contract EnigmaSimulation is EnigmaStorage, EnigmaEvents, Getters {
     }
 
     /**
-   * Commit the computation task results on chain by first verifying the receipts and then the worker's signature.
-   * The task records are finalized and the worker is credited with the tasks' fees.
-   *
-   * @param _scAddr Secret contract address
-   * @param _taskIds Unique taskId
-   * @param _stateDeltaHashes Input state delta hashes
-   * @param _outputHashes Output state hashes
-   * @param _optionalEthereumData Output state hashes
-   * @param _optionalEthereumContractAddress Output state hashes
-   * @param _gasesUsed Output state hashes
-   * @param _sig Worker's signature
-   */
-    function commitReceipts(
-        bytes32 _scAddr,
-        bytes32[] memory _taskIds,
-        bytes32[] memory _stateDeltaHashes,
-        bytes32[] memory _outputHashes,
-        bytes memory _optionalEthereumData,
-        address _optionalEthereumContractAddress,
-        uint64[] memory _gasesUsed,
-        bytes memory _sig
-    )
-    public
-    workerLoggedIn(msg.sender)
-    contractDeployed(_scAddr)
-    {
-        TaskImpl.commitReceiptsImpl(state, _scAddr, _taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-            _optionalEthereumContractAddress, _gasesUsed, _sig);
-    }
-
-    /**
     * Commit the computation task failure on chain - the task fee is transfered to the worker and the status is
     * updated to indicate task failure.
     *

--- a/contracts/impl/EnigmaCommon.sol
+++ b/contracts/impl/EnigmaCommon.sol
@@ -21,7 +21,7 @@ library EnigmaCommon {
         uint gasLimit; // ENG gas limit units
         uint gasPx; // ENG gas px in grains (10 ** 8) amount
         uint blockNumber; // Block number TaskRecord was mined
-        TaskStatus status; // RecordUndefined: 0; RecordCreated: 1; ReceiptVerified: 2; ReceiptFailed: 3
+        TaskStatus status; // RecordUndefined: 0; RecordCreated: 1; ReceiptVerified: 2; ReceiptFailed: 3; ReceiptFailedETH: 4; ReceiptFailedReturn: 5
         bytes proof; // Signature of (taskId, inStateDeltaHash, outStateDeltaHash, ethCall)
     }
 
@@ -61,7 +61,7 @@ library EnigmaCommon {
 
     // ========================================== Enums ==========================================
 
-    enum TaskStatus {RecordUndefined, RecordCreated, ReceiptVerified, ReceiptFailedENG, ReceiptFailedETH,
+    enum TaskStatus {RecordUndefined, RecordCreated, ReceiptVerified, ReceiptFailed, ReceiptFailedETH,
         ReceiptFailedReturn}
 
     enum WorkerStatus {Unregistered, LoggedIn, LoggedOut}

--- a/contracts/impl/EnigmaEvents.sol
+++ b/contracts/impl/EnigmaEvents.sol
@@ -20,7 +20,7 @@ contract EnigmaEvents {
         uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
-    event ReceiptFailedENG(bytes32 taskId, bytes sig);
+    event ReceiptFailed(bytes32 taskId, bytes sig);
     event ReceiptFailedETH(bytes32 taskId, bytes sig);
     event TaskFeeReturned(bytes32 taskId);
     event DepositSuccessful(address from, uint value);

--- a/contracts/impl/EnigmaEvents.sol
+++ b/contracts/impl/EnigmaEvents.sol
@@ -20,9 +20,8 @@ contract EnigmaEvents {
         uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
-    event ReceiptFailed(bytes32 taskId, bytes sig);
+    event ReceiptFailedENG(bytes32 taskId, bytes sig);
     event ReceiptFailedETH(bytes32 taskId, bytes sig);
-    event ReceiptsFailedETH(bytes32[] taskIds, bytes sig);
     event TaskFeeReturned(bytes32 taskId);
     event DepositSuccessful(address from, uint value);
     event WithdrawSuccessful(address to, uint value);

--- a/contracts/impl/TaskImpl.sol
+++ b/contracts/impl/TaskImpl.sol
@@ -32,9 +32,8 @@ library TaskImpl {
         uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
-    event ReceiptFailed(bytes32 taskId, bytes sig);
+    event ReceiptFailedENG(bytes32 taskId, bytes sig);
     event ReceiptFailedETH(bytes32 taskId, bytes sig);
-    event ReceiptsFailedETH(bytes32[] taskIds, bytes sig);
     event TaskFeeReturned(bytes32 taskId);
 
     function createDeploymentTaskRecordImpl(
@@ -104,7 +103,7 @@ library TaskImpl {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailed(_taskId, _sig);
+        emit ReceiptFailedENG(_taskId, _sig);
     }
 
     function verifyDeployReceipt(EnigmaState.State storage state, bytes32 _taskId, bytes32 _codeHash,
@@ -257,7 +256,7 @@ library TaskImpl {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailed(_taskId, _sig);
+        emit ReceiptFailedENG(_taskId, _sig);
     }
 
     function validateReceipt(EnigmaState.State storage state, uint64 _gasUsed, address _sender, bytes32 _scAddr,
@@ -429,61 +428,6 @@ library TaskImpl {
         message = EnigmaCommon.appendMessage(message, hex"01");
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[_sender].signer, "Invalid signature");
-    }
-
-    function commitReceiptsImpl(
-        EnigmaState.State storage state,
-        bytes32 _scAddr,
-        bytes32[] memory _taskIds,
-        bytes32[] memory _stateDeltaHashes,
-        bytes32[] memory _outputHashes,
-        bytes memory _optionalEthereumData,
-        address _optionalEthereumContractAddress,
-        uint64[] memory _gasesUsed,
-        bytes memory _sig
-    )
-    public
-    {
-        EnigmaCommon.SecretContract storage secretContract = state.contracts[_scAddr];
-
-        // Verify the receipt
-        verifyReceipts(state, _scAddr, _taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-            _optionalEthereumContractAddress, _gasesUsed, msg.sender, _sig);
-
-        if (_optionalEthereumContractAddress != address(0)) {
-            (bool success,) = _optionalEthereumContractAddress.call(_optionalEthereumData);
-            if (success) {
-                for (uint i = 0; i < _taskIds.length; i++) {
-                    EnigmaCommon.TaskRecord storage task = state.tasks[_taskIds[i]];
-                    transferFundsAfterTaskETH(state, msg.sender, task.gasLimit, task.gasPx);
-                    task.status = EnigmaCommon.TaskStatus.ReceiptVerified;
-                    task.proof = _sig;
-                    secretContract.stateDeltaHashes.push(_stateDeltaHashes[i]);
-                    task.outputHash = _outputHashes[i];
-                }
-                emit ReceiptsVerified(_taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-                    _optionalEthereumContractAddress, _sig);
-            } else {
-                for (uint i = 0; i < _taskIds.length; i++) {
-                    EnigmaCommon.TaskRecord storage task = state.tasks[_taskIds[i]];
-                    transferFundsAfterTaskETH(state, msg.sender, task.gasLimit, task.gasPx);
-                    task.status = EnigmaCommon.TaskStatus.ReceiptFailedETH;
-                    task.proof = _sig;
-                }
-                emit ReceiptsFailedETH(_taskIds, _sig);
-            }
-        } else {
-            for (uint i = 0; i < _taskIds.length; i++) {
-                EnigmaCommon.TaskRecord storage task = state.tasks[_taskIds[i]];
-                transferFundsAfterTask(state, msg.sender, task.sender, _gasesUsed[i], task.gasLimit.sub(_gasesUsed[i]), task.gasPx);
-                task.status = EnigmaCommon.TaskStatus.ReceiptVerified;
-                task.proof = _sig;
-                secretContract.stateDeltaHashes.push(_stateDeltaHashes[i]);
-                task.outputHash = _outputHashes[i];
-            }
-            emit ReceiptsVerified(_taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-                _optionalEthereumContractAddress, _sig);
-        }
     }
 
     function returnFeesForTaskImpl(

--- a/contracts/impl/TaskImpl.sol
+++ b/contracts/impl/TaskImpl.sol
@@ -32,7 +32,7 @@ library TaskImpl {
         uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
-    event ReceiptFailedENG(bytes32 taskId, bytes sig);
+    event ReceiptFailed(bytes32 taskId, bytes sig);
     event ReceiptFailedETH(bytes32 taskId, bytes sig);
     event TaskFeeReturned(bytes32 taskId);
 
@@ -91,7 +91,7 @@ library TaskImpl {
 
         // Update proof and status attributes of TaskRecord
         task.proof = _sig;
-        task.status = EnigmaCommon.TaskStatus.ReceiptFailedENG;
+        task.status = EnigmaCommon.TaskStatus.ReceiptFailed;
 
         transferFundsAfterTask(state, msg.sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
 
@@ -103,7 +103,7 @@ library TaskImpl {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailedENG(_taskId, _sig);
+        emit ReceiptFailed(_taskId, _sig);
     }
 
     function verifyDeployReceipt(EnigmaState.State storage state, bytes32 _taskId, bytes32 _codeHash,
@@ -243,7 +243,7 @@ library TaskImpl {
 
         // Update proof and status attributes of TaskRecord
         task.proof = _sig;
-        task.status = EnigmaCommon.TaskStatus.ReceiptFailedENG;
+        task.status = EnigmaCommon.TaskStatus.ReceiptFailed;
 
         transferFundsAfterTask(state, msg.sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
 
@@ -256,7 +256,7 @@ library TaskImpl {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailedENG(_taskId, _sig);
+        emit ReceiptFailed(_taskId, _sig);
     }
 
     function validateReceipt(EnigmaState.State storage state, uint64 _gasUsed, address _sender, bytes32 _scAddr,

--- a/contracts/impl/TaskImplSimulation.sol
+++ b/contracts/impl/TaskImplSimulation.sol
@@ -32,7 +32,7 @@ library TaskImplSimulation {
         uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
-    event ReceiptFailedENG(bytes32 taskId, bytes sig);
+    event ReceiptFailed(bytes32 taskId, bytes sig);
     event ReceiptFailedETH(bytes32 taskId, bytes sig);
     event TaskFeeReturned(bytes32 taskId);
 
@@ -91,7 +91,7 @@ library TaskImplSimulation {
 
         // Update proof and status attributes of TaskRecord
         task.proof = _sig;
-        task.status = EnigmaCommon.TaskStatus.ReceiptFailedENG;
+        task.status = EnigmaCommon.TaskStatus.ReceiptFailed;
 
         transferFundsAfterTask(state, msg.sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
 
@@ -103,7 +103,7 @@ library TaskImplSimulation {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailedENG(_taskId, _sig);
+        emit ReceiptFailed(_taskId, _sig);
     }
 
     function verifyDeployReceipt(EnigmaState.State storage state, bytes32 _taskId, bytes32 _codeHash,
@@ -243,7 +243,7 @@ library TaskImplSimulation {
 
         // Update proof and status attributes of TaskRecord
         task.proof = _sig;
-        task.status = EnigmaCommon.TaskStatus.ReceiptFailedENG;
+        task.status = EnigmaCommon.TaskStatus.ReceiptFailed;
 
         transferFundsAfterTask(state, msg.sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
 
@@ -256,7 +256,7 @@ library TaskImplSimulation {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailedENG(_taskId, _sig);
+        emit ReceiptFailed(_taskId, _sig);
     }
 
     function validateReceipt(EnigmaState.State storage state, uint64 _gasUsed, address _sender, bytes32 _scAddr,

--- a/contracts/impl/TaskImplSimulation.sol
+++ b/contracts/impl/TaskImplSimulation.sol
@@ -32,9 +32,8 @@ library TaskImplSimulation {
         uint deltaHashIndex, bytes optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
     event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
         bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
-    event ReceiptFailed(bytes32 taskId, bytes sig);
+    event ReceiptFailedENG(bytes32 taskId, bytes sig);
     event ReceiptFailedETH(bytes32 taskId, bytes sig);
-    event ReceiptsFailedETH(bytes32[] taskIds, bytes sig);
     event TaskFeeReturned(bytes32 taskId);
 
     function createDeploymentTaskRecordImpl(
@@ -104,7 +103,7 @@ library TaskImplSimulation {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailed(_taskId, _sig);
+        emit ReceiptFailedENG(_taskId, _sig);
     }
 
     function verifyDeployReceipt(EnigmaState.State storage state, bytes32 _taskId, bytes32 _codeHash,
@@ -257,7 +256,7 @@ library TaskImplSimulation {
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
-        emit ReceiptFailed(_taskId, _sig);
+        emit ReceiptFailedENG(_taskId, _sig);
     }
 
     function validateReceipt(EnigmaState.State storage state, uint64 _gasUsed, address _sender, bytes32 _scAddr,
@@ -429,61 +428,6 @@ library TaskImplSimulation {
         message = EnigmaCommon.appendMessage(message, hex"01");
         bytes32 msgHash = keccak256(message);
         require(msgHash.recover(_sig) == state.workers[_sender].signer, "Invalid signature");
-    }
-
-    function commitReceiptsImpl(
-        EnigmaState.State storage state,
-        bytes32 _scAddr,
-        bytes32[] memory _taskIds,
-        bytes32[] memory _stateDeltaHashes,
-        bytes32[] memory _outputHashes,
-        bytes memory _optionalEthereumData,
-        address _optionalEthereumContractAddress,
-        uint64[] memory _gasesUsed,
-        bytes memory _sig
-    )
-    public
-    {
-        EnigmaCommon.SecretContract storage secretContract = state.contracts[_scAddr];
-
-        // Verify the receipt
-        verifyReceipts(state, _scAddr, _taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-            _optionalEthereumContractAddress, _gasesUsed, msg.sender, _sig);
-
-        if (_optionalEthereumContractAddress != address(0)) {
-            (bool success,) = _optionalEthereumContractAddress.call(_optionalEthereumData);
-            if (success) {
-                for (uint i = 0; i < _taskIds.length; i++) {
-                    EnigmaCommon.TaskRecord storage task = state.tasks[_taskIds[i]];
-                    transferFundsAfterTaskETH(state, msg.sender, task.gasLimit, task.gasPx);
-                    task.status = EnigmaCommon.TaskStatus.ReceiptVerified;
-                    task.proof = _sig;
-                    secretContract.stateDeltaHashes.push(_stateDeltaHashes[i]);
-                    task.outputHash = _outputHashes[i];
-                }
-                emit ReceiptsVerified(_taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-                    _optionalEthereumContractAddress, _sig);
-            } else {
-                for (uint i = 0; i < _taskIds.length; i++) {
-                    EnigmaCommon.TaskRecord storage task = state.tasks[_taskIds[i]];
-                    transferFundsAfterTaskETH(state, msg.sender, task.gasLimit, task.gasPx);
-                    task.status = EnigmaCommon.TaskStatus.ReceiptFailedETH;
-                    task.proof = _sig;
-                }
-                emit ReceiptsFailedETH(_taskIds, _sig);
-            }
-        } else {
-            for (uint i = 0; i < _taskIds.length; i++) {
-                EnigmaCommon.TaskRecord storage task = state.tasks[_taskIds[i]];
-                transferFundsAfterTask(state, msg.sender, task.sender, _gasesUsed[i], task.gasLimit.sub(_gasesUsed[i]), task.gasPx);
-                task.status = EnigmaCommon.TaskStatus.ReceiptVerified;
-                task.proof = _sig;
-                secretContract.stateDeltaHashes.push(_stateDeltaHashes[i]);
-                task.outputHash = _outputHashes[i];
-            }
-            emit ReceiptsVerified(_taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
-                _optionalEthereumContractAddress, _sig);
-        }
     }
 
     function returnFeesForTaskImpl(

--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -2027,62 +2027,6 @@ describe('Enigma tests', () => {
       }
     });
 
-
-    // let stateDeltaHashes;
-    // let outputHashes;
-    // it('should simulate multiple task receipts', async () => {
-    //   const gasesUsed = [25, 10];
-    //   const stateDeltaHash2 = web3.utils.soliditySha3('stateDeltaHash2');
-    //   const stateDeltaHash3 = web3.utils.soliditySha3('stateDeltaHash3');
-    //   stateDeltaHashes = [stateDeltaHash2, stateDeltaHash3];
-    //   const outputHash2 = web3.utils.soliditySha3('outputHash2');
-    //   const outputHash3 = web3.utils.soliditySha3('outputHash3');
-    //   outputHashes = [outputHash2, outputHash3];
-    //   const taskIds = tasks.map((task) => task.taskId);
-    //   const inputsHashes = tasks.map((task) => task.inputsHash);
-    //   const optionalEthereumData = '0x00';
-    //   const optionalEthereumContractAddress = '0x0000000000000000000000000000000000000000';
-    //   const proof = utils.commitReceiptsHash(codeHash, inputsHashes, stateDeltaHash, stateDeltaHashes, outputHashes,
-    //     gasesUsed.map((gasUsed) => web3.utils.toBN(gasUsed).toString(16, 16)), optionalEthereumData, optionalEthereumContractAddress, '0x01');
-    //   const workerParams = await enigma.getWorkerParams(task.creationBlockNumber);
-    //   const selectedWorkerAddr = (await enigma.selectWorkerGroup(task.scAddr, workerParams, 1))[0];
-    //   const priv = data.workers.find((w) => w[0] === selectedWorkerAddr.toLowerCase())[4];
-    //   const sig = EthCrypto.sign(priv, proof);
-    //   let worker = await enigma.admin.findBySigningAddress(selectedWorkerAddr);
-    //   const startingWorkerBalance = worker.balance;
-    //   const startingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
-    //   const result = await new Promise((resolve, reject) => {
-    //     enigma.enigmaContract.methods.commitReceipts(scAddr, taskIds, stateDeltaHashes, outputHashes,
-    //       optionalEthereumData,
-    //       optionalEthereumContractAddress, gasesUsed, sig).send({
-    //       from: worker.account,
-    //     }).on('receipt', (receipt) => resolve(receipt)).on('error', (error) => reject(error));
-    //   });
-    //   worker = await enigma.admin.findBySigningAddress(selectedWorkerAddr);
-    //   const endingWorkerBalance = worker.balance;
-    //   const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
-    //   expect(endingWorkerBalance - startingWorkerBalance).toEqual((gasesUsed[0] * tasks[0].gasPx) +
-    //     (gasesUsed[1] * tasks[1].gasPx));
-    //   expect(endingSenderBalance - startingSenderBalance).
-    //     toEqual(((tasks[0].gasLimit - gasesUsed[0]) * tasks[0].gasPx) +
-    //       ((tasks[1].gasLimit - gasesUsed[1]) * tasks[1].gasPx));
-    //   expect(result.events.ReceiptsVerified).toBeTruthy();
-    // });
-
-    it('should get the confirmed tasks', async () => {
-      for (let i = 0; i < tasks.length; i++) {
-        tasks[i] = await enigma.getTaskRecordStatus(tasks[i]);
-        expect(tasks[i].ethStatus).toEqual(2);
-      }
-    });
-
-    it('should get state delta hash range', async () => {
-      const hashes = await enigma.admin.getStateDeltaHashes(scAddr, 0, 5);
-      expect(hashes).toEqual([
-        initStateDeltaHash, stateDeltaHash, stateDeltaHash, stateDeltaHashes[0],
-        stateDeltaHashes[1]]);
-    });
-
     it('should verify the report', async () => {
       let worker = data.workers[0];
 

--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -701,7 +701,7 @@ describe('Enigma tests', () => {
       const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(scTask.sender).call());
       expect(endingWorkerBalance - startingWorkerBalance).toEqual(gasUsed * scTask.gasPx);
       expect(endingSenderBalance - startingSenderBalance).toEqual((scTask.gasLimit - gasUsed) * scTask.gasPx);
-      expect(result.events.ReceiptFailedENG).toBeTruthy();
+      expect(result.events.ReceiptFailed).toBeTruthy();
     });
 
     it('should fail to simulate contract deployment of already failed task', async () => {
@@ -1370,7 +1370,7 @@ describe('Enigma tests', () => {
       const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
       expect(endingWorkerBalance - startingWorkerBalance).toEqual(gasUsed * task.gasPx);
       expect(endingSenderBalance - startingSenderBalance).toEqual((task.gasLimit - gasUsed) * task.gasPx);
-      expect(result.events.ReceiptFailedENG).toBeTruthy();
+      expect(result.events.ReceiptFailed).toBeTruthy();
     });
 
     it('should count state deltas after task failure', async () => {

--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -701,7 +701,7 @@ describe('Enigma tests', () => {
       const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(scTask.sender).call());
       expect(endingWorkerBalance - startingWorkerBalance).toEqual(gasUsed * scTask.gasPx);
       expect(endingSenderBalance - startingSenderBalance).toEqual((scTask.gasLimit - gasUsed) * scTask.gasPx);
-      expect(result.events.ReceiptFailed).toBeTruthy();
+      expect(result.events.ReceiptFailedENG).toBeTruthy();
     });
 
     it('should fail to simulate contract deployment of already failed task', async () => {
@@ -1370,7 +1370,7 @@ describe('Enigma tests', () => {
       const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
       expect(endingWorkerBalance - startingWorkerBalance).toEqual(gasUsed * task.gasPx);
       expect(endingSenderBalance - startingSenderBalance).toEqual((task.gasLimit - gasUsed) * task.gasPx);
-      expect(result.events.ReceiptFailed).toBeTruthy();
+      expect(result.events.ReceiptFailedENG).toBeTruthy();
     });
 
     it('should count state deltas after task failure', async () => {

--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -2028,46 +2028,46 @@ describe('Enigma tests', () => {
     });
 
 
-    let stateDeltaHashes;
-    let outputHashes;
-    it('should simulate multiple task receipts', async () => {
-      const gasesUsed = [25, 10];
-      const stateDeltaHash2 = web3.utils.soliditySha3('stateDeltaHash2');
-      const stateDeltaHash3 = web3.utils.soliditySha3('stateDeltaHash3');
-      stateDeltaHashes = [stateDeltaHash2, stateDeltaHash3];
-      const outputHash2 = web3.utils.soliditySha3('outputHash2');
-      const outputHash3 = web3.utils.soliditySha3('outputHash3');
-      outputHashes = [outputHash2, outputHash3];
-      const taskIds = tasks.map((task) => task.taskId);
-      const inputsHashes = tasks.map((task) => task.inputsHash);
-      const optionalEthereumData = '0x00';
-      const optionalEthereumContractAddress = '0x0000000000000000000000000000000000000000';
-      const proof = utils.commitReceiptsHash(codeHash, inputsHashes, stateDeltaHash, stateDeltaHashes, outputHashes,
-        gasesUsed.map((gasUsed) => web3.utils.toBN(gasUsed).toString(16, 16)), optionalEthereumData, optionalEthereumContractAddress, '0x01');
-      const workerParams = await enigma.getWorkerParams(task.creationBlockNumber);
-      const selectedWorkerAddr = (await enigma.selectWorkerGroup(task.scAddr, workerParams, 1))[0];
-      const priv = data.workers.find((w) => w[0] === selectedWorkerAddr.toLowerCase())[4];
-      const sig = EthCrypto.sign(priv, proof);
-      let worker = await enigma.admin.findBySigningAddress(selectedWorkerAddr);
-      const startingWorkerBalance = worker.balance;
-      const startingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
-      const result = await new Promise((resolve, reject) => {
-        enigma.enigmaContract.methods.commitReceipts(scAddr, taskIds, stateDeltaHashes, outputHashes,
-          optionalEthereumData,
-          optionalEthereumContractAddress, gasesUsed, sig).send({
-          from: worker.account,
-        }).on('receipt', (receipt) => resolve(receipt)).on('error', (error) => reject(error));
-      });
-      worker = await enigma.admin.findBySigningAddress(selectedWorkerAddr);
-      const endingWorkerBalance = worker.balance;
-      const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
-      expect(endingWorkerBalance - startingWorkerBalance).toEqual((gasesUsed[0] * tasks[0].gasPx) +
-        (gasesUsed[1] * tasks[1].gasPx));
-      expect(endingSenderBalance - startingSenderBalance).
-        toEqual(((tasks[0].gasLimit - gasesUsed[0]) * tasks[0].gasPx) +
-          ((tasks[1].gasLimit - gasesUsed[1]) * tasks[1].gasPx));
-      expect(result.events.ReceiptsVerified).toBeTruthy();
-    });
+    // let stateDeltaHashes;
+    // let outputHashes;
+    // it('should simulate multiple task receipts', async () => {
+    //   const gasesUsed = [25, 10];
+    //   const stateDeltaHash2 = web3.utils.soliditySha3('stateDeltaHash2');
+    //   const stateDeltaHash3 = web3.utils.soliditySha3('stateDeltaHash3');
+    //   stateDeltaHashes = [stateDeltaHash2, stateDeltaHash3];
+    //   const outputHash2 = web3.utils.soliditySha3('outputHash2');
+    //   const outputHash3 = web3.utils.soliditySha3('outputHash3');
+    //   outputHashes = [outputHash2, outputHash3];
+    //   const taskIds = tasks.map((task) => task.taskId);
+    //   const inputsHashes = tasks.map((task) => task.inputsHash);
+    //   const optionalEthereumData = '0x00';
+    //   const optionalEthereumContractAddress = '0x0000000000000000000000000000000000000000';
+    //   const proof = utils.commitReceiptsHash(codeHash, inputsHashes, stateDeltaHash, stateDeltaHashes, outputHashes,
+    //     gasesUsed.map((gasUsed) => web3.utils.toBN(gasUsed).toString(16, 16)), optionalEthereumData, optionalEthereumContractAddress, '0x01');
+    //   const workerParams = await enigma.getWorkerParams(task.creationBlockNumber);
+    //   const selectedWorkerAddr = (await enigma.selectWorkerGroup(task.scAddr, workerParams, 1))[0];
+    //   const priv = data.workers.find((w) => w[0] === selectedWorkerAddr.toLowerCase())[4];
+    //   const sig = EthCrypto.sign(priv, proof);
+    //   let worker = await enigma.admin.findBySigningAddress(selectedWorkerAddr);
+    //   const startingWorkerBalance = worker.balance;
+    //   const startingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
+    //   const result = await new Promise((resolve, reject) => {
+    //     enigma.enigmaContract.methods.commitReceipts(scAddr, taskIds, stateDeltaHashes, outputHashes,
+    //       optionalEthereumData,
+    //       optionalEthereumContractAddress, gasesUsed, sig).send({
+    //       from: worker.account,
+    //     }).on('receipt', (receipt) => resolve(receipt)).on('error', (error) => reject(error));
+    //   });
+    //   worker = await enigma.admin.findBySigningAddress(selectedWorkerAddr);
+    //   const endingWorkerBalance = worker.balance;
+    //   const endingSenderBalance = parseInt(await enigma.tokenContract.methods.balanceOf(task.sender).call());
+    //   expect(endingWorkerBalance - startingWorkerBalance).toEqual((gasesUsed[0] * tasks[0].gasPx) +
+    //     (gasesUsed[1] * tasks[1].gasPx));
+    //   expect(endingSenderBalance - startingSenderBalance).
+    //     toEqual(((tasks[0].gasLimit - gasesUsed[0]) * tasks[0].gasPx) +
+    //       ((tasks[1].gasLimit - gasesUsed[1]) * tasks[1].gasPx));
+    //   expect(result.events.ReceiptsVerified).toBeTruthy();
+    // });
 
     it('should get the confirmed tasks', async () => {
       for (let i = 0; i < tasks.length; i++) {


### PR DESCRIPTION
Implements the following:

1. Remove unused code from the contract (`commitReceipts`)
2. Align the `ReceiptFailed` event to the `ReceiptFailedENG` status

After some thoughts regarding 2, did the opposite:  aligned the `ReceiptFailedENG` status to the `ReceiptFailed` event
