### PR TITLE
TST: added test to compute time worker is logged in

### DIFF
--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -419,6 +419,34 @@ describe('Enigma tests', () => {
           'epoch as log out event');
     });
 
+    it('should compute the number of blocks a worker has been logged in', async () => {
+      // get the worker struct that contains the workerLogs
+      let worker = await enigma.enigmaContract.methods.getWorker(accounts[0]).call();
+
+      let loggedIn = 0;
+      let active = 0;
+
+      // iterate through all the items stored in the workerLogs
+      worker.workerLogs.forEach(function(e){
+        if(parseInt(e['workerEventType'])==1){
+          // if there is a log in event, temporarily store the blockNumber when that happened
+          loggedIn=parseInt(e['blockNumber']);
+        } else if (parseInt(e['workerEventType'])==2) {
+          // if there is a log out event, substract its blockNumber from that of the log in event
+          active += parseInt(e['blockNumber'])-loggedIn;
+          loggedIn=0
+        }
+      });
+      // after iterating all items, if worker is still logged in, substract it from the current block
+      if(loggedIn) {
+        const blockNumberNow = await web3.eth.getBlockNumber();
+        active += blockNumberNow - loggedIn
+      }
+      // the variable `active` contains the total number of blocks a worker has been active (logged in)
+      expect(active).toEqual(11);
+      expect(loggedIn).toBeTruthy();
+    });
+
     it('should set the worker parameters (principal only) again for a new epoch', async () => {
       let receipt;
       if (process.env.PRINCIPAL_CONTAINER) {


### PR DESCRIPTION
Adds a unit test to compute the amount of time (in number of blocks) a given worker has been active (logged in) in the network. It iterates through multiple log in and log out events and checks for the actual number of blocks that a worker has been active. If the worker is still logged in, uses the currentBlock to compute the remaining blocks since the last time it logged in.

This code is provided as a reference to compute when a worker will be active in the Genesis Game.