### PR TITLE
MAINT: randomize backoff of retrials from #155

### DIFF
--- a/enigma-js/src/Enigma.js
+++ b/enigma-js/src/Enigma.js
@@ -44,7 +44,7 @@ export default class Enigma {
     this.config.retry.maxTimeout = config.retry ?
       (config.retry.maxTimeout != null ? config.retry.maxTimeout : 'Infinity') : 'Infinity';
     this.config.retry.randomize = config.retry ?
-      (config.retry.randomize != null ? config.retry.randomize : false) : false;
+      (config.retry.randomize != null ? config.retry.randomize : true) : true;
 
     // axios callback for jayson rpc client to interface with ENG network
     let callServer = function(request, callback) {


### PR DESCRIPTION
Trivial change, changing the default from `false` to `true` to have a randomization factor when computing the exponential backoff delay. Change to #155.