### PR TITLE
MAINT: make the CI fail fast when an error is encountered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
   - sleep 5
 
 script:
+  - set -e
   - rm -rf build
   - truffle compile
   - truffle migrate --reset --network develop


### PR DESCRIPTION
This PR makes TravisCI fail fast, meaning the build will abort at the first command that errors out, otherwise it continues running until the end or until it times out. This is a known limitation of Travis covered here: https://github.com/travis-ci/travis-ci/issues/1066