### PR TITLE
MAINT: builds match branches across repos

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,28 +2,9 @@ kind: pipeline
 name: default
 steps:
 
-  - name: contract
-    image: node:10
-    privileged: true
-    commands:
-      - ./scripts/checkSimulationContracts.bash
-      - apt-get update && apt-get install build-essential
-      - yarn install
-      - yarn global add truffle ganache-cli
-      - ganache-cli -p 9545 -i 4447 &
-      - cd enigma-js && yarn install && cd ..
-      - rm -rf build
-      - truffle compile
-      - truffle migrate --reset --network develop
-      - cd enigma-js && yarn build && cd ..
-      - SGX_MODE=SW truffle migrate --reset --network develop
-      - cd enigma-js && SGX_MODE=SW yarn test && cd ..
-
   - name: integration
     image: enigmampc/docker-client
     privileged: true
-    depends_on: 
-      - contract
     volumes:
       - name: sock
         path: /var/run/docker.sock
@@ -31,71 +12,47 @@ steps:
       - git clone https://github.com/enigmampc/discovery-docker-network.git
       - cd discovery-docker-network && cp .env-template .env
       - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
-      - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
-      - export DOCKER_TAG=contract_${DRONE_BUILD_NUMBER}
+      - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
+      - export DOCKER_TAG=p2p_${DRONE_BUILD_NUMBER}
       - sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${DOCKER_TAG}/" .env;
       - |
-        if [[ "${DRONE_BRANCH}" == "master" ]]; then
-          docker pull enigmampc/enigma_core_hw:latest
-          docker pull enigmampc/enigma_km_hw:latest
-          docker pull enigmampc/enigma_p2p:latest
-          docker tag enigmampc/enigma_core_hw:latest enigmampc/enigma_core_hw:$DOCKER_TAG
-          docker tag enigmampc/enigma_km_hw:latest enigmampc/enigma_km_hw:$DOCKER_TAG
-          docker tag enigmampc/enigma_p2p:latest enigmampc/enigma_p2p:$DOCKER_TAG
-        else
-          if [ $MATCHING_BRANCH_P2P -eq 0 ] &&  [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-            docker pull enigmampc/enigma_core_hw:develop
-            docker pull enigmampc/enigma_km_hw:develop
-            docker pull enigmampc/enigma_p2p:develop
-            docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
-            docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
-            docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
+        /bin/bash -c '
+        declare -a PROJECTS=(core km p2p)
+        declare -A DOCKER_IMAGES=([core]=enigma_core_hw [km]=enigma_km_hw [p2p]=enigma_p2p)
+        declare -A GIT_BRANCH_ARG=([core]=GIT_BRANCH_CORE [km]=GIT_BRANCH_CORE [p2p]=GIT_BRANCH_P2P)
+        declare -A PROJECT_DIRECTORY=([core]=enigma-core [km]=enigma-core [p2p]=enigma-p2p)
+        declare -A PROJECT_BRANCH_FOUND=([core]=$MATCHING_BRANCH_CORE [km]=$MATCHING_BRANCH_CORE [p2p]=$MATCHING_BRANCH_P2P)
+        for project in $${PROJECTS[@]}; do
+          DOCKER_IMAGE="enigmampc/$${DOCKER_IMAGES[$project]}"
+          if [[ "$DRONE_BRANCH" == "master" ]]; then
+            docker pull "$DOCKER_IMAGE:latest"
+            docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$DOCKER_TAG"
+          elif [ "$${PROJECT_BRANCH_FOUND[$project]}" -eq 0 ]; then
+            docker pull "$DOCKER_IMAGE:develop"
+            docker tag "$DOCKER_IMAGE:develop" "$DOCKER_IMAGE:$DOCKER_TAG"
           else
-            if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
-              docker pull enigmampc/enigma_core_hw:develop
-              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
-              docker pull enigmampc/enigma_km_hw:develop
-              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
+            cd "$${PROJECT_DIRECTORY[$project]}"
+            if [[ "$project" == "km" ]]; then
+              docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
+            elif [[ "$project" == "core" ]]; then
+              docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
             else
-              if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
-                cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
-                cd ..
-                docker pull enigmampc/enigma_p2p:develop
-                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
-              else
-                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
-                cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
-                cd ..
-              fi
+              docker build --build-arg "$${GIT_BRANCH_ARG[$project]}=${DRONE_BRANCH}" -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
             fi
+            cd ..
           fi
-        fi
+        done'
       - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
       - export NODES=3
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml down -v --rmi all || true
       - if [ $RESULT -ne 0 ]; then exit 1; fi
 
-  - name: coverage
-    image: node:10
-    depends_on: 
-      - integration
-    environment:
-      CODECOV_TOKEN:
-        from_secret: CODECOV_TOKEN
-    commands:
-      - cd enigma-js && yarn report-coverage
-
   - name: deploy
     image: enigmampc/docker-client
     depends_on:
-      - coverage
+      - integration
     when:
       branch:
         - develop

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,28 +2,22 @@ kind: pipeline
 type: docker
 name: default
 steps:
-  - name: ganache
-    image: trufflesuite/ganache-cli:v6.4.3
-    detach: true
-    commands:
-      - node /app/ganache-core.docker.cli.js -p 9545 -i 4447
 
   - name: contract
     image: node:10
-    depends_on: 
-      - ganache
     privileged: true
     commands:
       - ./scripts/checkSimulationContracts.bash
       - apt-get update && apt-get install build-essential
       - yarn install
-      - yarn global add truffle
+      - yarn global add truffle ganache-cli
+      - ganache-cli -p 9545 -i 4447 &
       - cd enigma-js && yarn install && cd ..
       - rm -rf build
       - truffle compile
-      - truffle migrate --reset --network drone
+      - truffle migrate --reset --network develop
       - cd enigma-js && yarn build && cd ..
-      - SGX_MODE=SW truffle migrate --reset --network drone
+      - SGX_MODE=SW truffle migrate --reset --network develop
       - cd enigma-js && SGX_MODE=SW yarn test && cd ..
 
   - name: integration

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,8 @@ steps:
 
   - name: contract
     image: node:10
-    depends_on: ganache
+    depends_on: 
+      - ganache
     privileged: true
     commands:
       - ./scripts/checkSimulationContracts.bash
@@ -26,7 +27,8 @@ steps:
 
   - name: integration
     image: enigmampc/docker-client
-    depends_on: contract
+    depends_on: 
+      - contract
     privileged: true
     volumes:
       - name: sock
@@ -77,7 +79,8 @@ steps:
 
   - name: coverage
     image: node:10
-    depends_on: integration
+    depends_on: 
+      - integration
     commands:
       - pushd enigma-js && yarn report-coverage && popd
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,6 +86,9 @@ steps:
     image: node:10
     depends_on: 
       - integration
+    environment:
+      CODECOV_TOKEN:
+        from_secret: CODECOV_TOKEN
     commands:
       - cd enigma-js && yarn report-coverage
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,13 +17,13 @@ steps:
       - ./scripts/checkSimulationContracts.bash
       - yarn install
       - yarn global add truffle
-      - pushd enigma-js && yarn install && popd
+      - cd enigma-js && yarn install && cd ..
       - rm -rf build
       - truffle compile
       - truffle migrate --reset --network drone
-      - pushd enigma-js && yarn build && popd
+      - cd enigma-js && yarn build && cd ..
       - SGX_MODE=SW truffle migrate --reset --network drone
-      - pushd enigma-js && SGX_MODE=SW yarn test && popd
+      - cd enigma-js && SGX_MODE=SW yarn test && cd ..
 
   - name: integration
     image: enigmampc/docker-client

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,7 @@ steps:
     privileged: true
     commands:
       - ./scripts/checkSimulationContracts.bash
+      - apt-get update && apt-get install build-essential
       - yarn install
       - yarn global add truffle
       - cd enigma-js && yarn install && cd ..

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,5 +105,5 @@ steps:
       - cd discovery-docker-network/enigma-contract
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
       - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-      - docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:${TAG} --no-cache .
-      - docker push enigmampc/enigma_contract:${TAG}
+      - docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache .
+      - docker push enigmampc/enigma_contract:$TAG

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,16 +67,15 @@ steps:
             fi
           fi
         fi
-      - cd ..
-      - pushd discovery-docker-network/enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && popd
-      - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
+      - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
 
   - name: coverage
     image: node:10
     depends_on: 
       - integration
     commands:
-      - pushd enigma-js && yarn report-coverage && popd
+      - cd enigma-js && yarn report-coverage
 
   - name: deploy
     image: enigmampc/docker-client

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,9 +21,9 @@ steps:
 
   - name: integration
     image: enigmampc/docker-client
+    privileged: true
     depends_on: 
       - contract
-    privileged: true
     volumes:
       - name: sock
         path: /var/run/docker.sock
@@ -34,11 +34,11 @@ steps:
       - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
       - |
-        if [[ ${DRONE_BRANCH} == "master" ]]; then
+        if [[ "${DRONE_BRANCH}" == "master" ]]; then
           export TAG=latest;
           docker-compose pull
         else
-          if ! (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CORE )); then
+          if [ $MATCHING_BRANCH_P2P -eq 0 ] &&  [ $MATCHING_BRANCH_CORE -eq 0 ]; then
             export TAG=develop;
             sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
             docker-compose pull
@@ -68,7 +68,10 @@ steps:
           fi
         fi
       - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
-      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
+      - export NODES=3
+      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
+      - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
+      - if [ $RESULT -ne 0 ]; exit 1; fi
 
   - name: coverage
     image: node:10

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,8 +47,10 @@ steps:
             sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
             if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
               cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
-              docker pull enigmampc/enigma_contract:develop
-              docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+              docker pull enigmampc/enigma_core_hw:develop
+              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$TAG
+              docker pull enigmampc/enigma_km_hw:develop
+              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$TAG
             else
               if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
                 cd enigma-core
@@ -71,7 +73,7 @@ steps:
       - export NODES=3
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
       - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
-      - if [ $RESULT -ne 0 ]; exit 1; fi
+      - if [ $RESULT -ne 0 ]; then exit 1; fi
 
   - name: coverage
     image: node:10

--- a/.drone.yml
+++ b/.drone.yml
@@ -101,3 +101,8 @@ steps:
       - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
       - docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache .
       - docker push enigmampc/enigma_contract:$TAG
+
+volumes:
+  - name: sock
+    host:
+      path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,103 @@
+kind: pipeline
+type: docker
+name: default
+steps:
+  - name: ganache
+    image: trufflesuite/ganache-cli:v6.4.3
+    detach: true
+    commands:
+      - node /app/ganache-core.docker.cli.js -p 9545 -i 4447
+
+  - name: contract
+    image: node:10
+    depends_on: ganache
+    privileged: true
+    commands:
+      - ./scripts/checkSimulationContracts.bash
+      - yarn install
+      - yarn global add truffle
+      - pushd enigma-js && yarn install && popd
+      - rm -rf build
+      - truffle compile
+      - truffle migrate --reset --network drone
+      - pushd enigma-js && yarn build && popd
+      - SGX_MODE=SW truffle migrate --reset --network drone
+      - pushd enigma-js && SGX_MODE=SW yarn test && popd
+
+  - name: integration
+    image: enigmampc/docker-client
+    depends_on: contract
+    privileged: true
+    volumes:
+      - name: sock
+        path: /var/run/docker.sock
+    commands:
+      - git clone https://github.com/enigmampc/discovery-docker-network.git
+      - cd discovery-docker-network && cp .env-template .env
+      - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
+      - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
+      - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
+      - |
+        if [[ ${DRONE_BRANCH} == "master" ]]; then
+          export TAG=latest;
+          docker-compose pull
+        else
+          if ! (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CORE )); then
+            export TAG=develop;
+            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
+            docker-compose pull
+          else
+            export TAG=$DRONE_BRANCH;
+            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
+            if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
+              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+              docker pull enigmampc/enigma_contract:develop
+              docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+            else
+              if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
+                cd enigma-core
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                cd ..
+                docker pull enigmampc/enigma_p2p:develop
+                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$TAG
+              else
+                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+                cd enigma-core
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                cd ..
+              fi
+            fi
+          fi
+        fi
+      - cd ..
+      - pushd discovery-docker-network/enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=$DRONE_BRANCH -t enigmampc/enigma_contract:$TAG --no-cache . && popd
+      - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
+
+  - name: coverage
+    image: node:10
+    depends_on: integration
+    commands:
+      - pushd enigma-js && yarn report-coverage && popd
+
+  - name: deploy
+    image: enigmampc/docker-client
+    depends_on:
+      - coverage
+    when:
+      branch:
+        - develop
+        - master
+    environment:
+      USERNAME:
+        from_secret: username
+      PASSWORD:
+        from_secret: password
+    commands:
+      - cd discovery-docker-network/enigma-contract
+      - echo $PASSWORD | docker login -u $USERNAME --password-stdin
+      - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
+      - docker build --build-arg GIT_BRANCH_CONTRACT=$DRONE_BRANCH -t enigmampc/enigma_contract:${TAG} --no-cache .
+      - docker push enigmampc/enigma_contract:$TAG
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,7 +49,7 @@ steps:
             sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
             docker-compose pull
           else
-            export TAG=$DRONE_BRANCH;
+            export TAG=${DRONE_BRANCH};
             sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
             if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
               cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
@@ -74,7 +74,7 @@ steps:
           fi
         fi
       - cd ..
-      - pushd discovery-docker-network/enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=$DRONE_BRANCH -t enigmampc/enigma_contract:$TAG --no-cache . && popd
+      - pushd discovery-docker-network/enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && popd
       - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
 
   - name: coverage
@@ -92,6 +92,10 @@ steps:
       branch:
         - develop
         - master
+    privileged: true
+    volumes:
+      - name: sock
+        path: /var/run/docker.sock
     environment:
       USERNAME:
         from_secret: username
@@ -101,6 +105,5 @@ steps:
       - cd discovery-docker-network/enigma-contract
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
       - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-      - docker build --build-arg GIT_BRANCH_CONTRACT=$DRONE_BRANCH -t enigmampc/enigma_contract:${TAG} --no-cache .
-      - docker push enigmampc/enigma_contract:$TAG
-
+      - docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:${TAG} --no-cache .
+      - docker push enigmampc/enigma_contract:${TAG}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,4 @@
 kind: pipeline
-type: docker
 name: default
 steps:
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -68,7 +68,7 @@ steps:
           fi
         fi
       - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
-      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
+      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
 
   - name: coverage
     image: node:10

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,46 +33,53 @@ steps:
       - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
       - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
+      - export DOCKER_TAG=contract_${DRONE_BUILD_NUMBER}
+      - sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${DOCKER_TAG}/" .env;
       - |
         if [[ "${DRONE_BRANCH}" == "master" ]]; then
-          export TAG=latest;
-          docker-compose pull
+          docker pull enigmampc/enigma_core_hw:latest
+          docker pull enigmampc/enigma_km_hw:latest
+          docker pull enigmampc/enigma_p2p:latest
+          docker tag enigmampc/enigma_core_hw:latest enigmampc/enigma_core_hw:$DOCKER_TAG
+          docker tag enigmampc/enigma_km_hw:latest enigmampc/enigma_km_hw:$DOCKER_TAG
+          docker tag enigmampc/enigma_p2p:latest enigmampc/enigma_p2p:$DOCKER_TAG
         else
           if [ $MATCHING_BRANCH_P2P -eq 0 ] &&  [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-            export TAG=develop;
-            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
-            docker-compose pull
+            docker pull enigmampc/enigma_core_hw:develop
+            docker pull enigmampc/enigma_km_hw:develop
+            docker pull enigmampc/enigma_p2p:develop
+            docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
+            docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
+            docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
           else
-            export TAG=${DRONE_BRANCH};
-            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
             if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
               docker pull enigmampc/enigma_core_hw:develop
-              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$TAG
+              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
               docker pull enigmampc/enigma_km_hw:develop
-              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$TAG
+              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
             else
               if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
                 cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
                 cd ..
                 docker pull enigmampc/enigma_p2p:develop
-                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$TAG
+                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
               else
-                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
                 cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
                 cd ..
               fi
             fi
           fi
         fi
-      - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+      - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
       - export NODES=3
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
-      - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
+      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml down -v --rmi all || true
       - if [ $RESULT -ne 0 ]; then exit 1; fi
 
   - name: coverage
@@ -102,9 +109,9 @@ steps:
     commands:
       - cd discovery-docker-network/enigma-contract
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
-      - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-      - docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache .
-      - docker push enigmampc/enigma_contract:$TAG
+      - if [[ ${DRONE_BRANCH} == "master" ]]; then export DOCKER_TAG=latest; else export DOCKER_TAG=develop; fi
+      - docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache .
+      - docker push enigmampc/enigma_contract:$DOCKER_TAG
 
 volumes:
   - name: sock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,7 @@ language: node_js
 sudo: true
 
 node_js:
-  - "10.14"
-
-services:
-  - docker
-
-env:
-  - DOCKER_COMPOSE_VERSION=1.23.2
-
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
+  - "10.16"
 
 install:
   - ./scripts/checkSimulationContracts.bash
@@ -35,55 +23,6 @@ script:
   - pushd enigma-js && yarn build && popd
   - SGX_MODE=SW truffle migrate --reset --network develop
   - pushd enigma-js && SGX_MODE=SW yarn test && popd
-  - git clone https://github.com/enigmampc/discovery-docker-network.git
-  - cd discovery-docker-network
-  - cp .env-template .env && sed -i "s/SGX_MODE=HW/SGX_MODE=SW/" .env
-  - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${TRAVIS_BRANCH} | wc -l)"
-  - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${TRAVIS_BRANCH} | wc -l)"
-  - |
-    if [[ ${TRAVIS_BRANCH} == "master" ]]; then
-      export TAG=latest;
-      docker-compose pull
-    else
-      if ! (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CORE )); then
-        export TAG=develop;
-        sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
-        docker-compose pull
-      else
-        export TAG=$TRAVIS_BRANCH;
-        sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
-        if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-          cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${TRAVIS_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
-          docker pull enigmampc/enigma_contract:develop
-          docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
-        else
-          if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
-            cd enigma-core
-            docker build --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$TAG --no-cache .
-            docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$TAG --no-cache .
-            cd ..
-            docker pull enigmampc/enigma_p2p:develop
-            docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$TAG
-          else
-            cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${TRAVIS_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
-            cd enigma-core
-            docker build --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$TAG --no-cache .
-            docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$TAG --no-cache .
-            cd ..
-          fi
-        fi
-      fi
-    fi
-  - cd ..
-  - pushd discovery-docker-network/enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=$TRAVIS_BRANCH -t enigmampc/enigma_contract:$TAG --no-cache . && popd
-  - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
 
 after_success:
   - pushd enigma-js && yarn report-coverage && popd
-
-deploy:
-  provider: script
-  script: bash scripts/deploy.sh
-  on:
-    all_branches: true
-    condition: $TRAVIS_BRANCH =~ ^master|develop$

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,45 @@ script:
   - SGX_MODE=SW truffle migrate --reset --network develop
   - pushd enigma-js && SGX_MODE=SW yarn test && popd
   - git clone https://github.com/enigmampc/discovery-docker-network.git
-  - if [[ $TRAVIS_BRANCH == "master" ]]; then export TAG=latest; else export TAG=develop; fi
+  - cd discovery-docker-network
+  - cp .env-template .env && sed -i "s/SGX_MODE=HW/SGX_MODE=SW/" .env
+  - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${TRAVIS_BRANCH} | wc -l)"
+  - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${TRAVIS_BRANCH} | wc -l)"
   - |
-    pushd discovery-docker-network &&
-    cp .env-template .env &&
-    sed -i "s/SGX_MODE=HW/SGX_MODE=SW/" .env &&
-    if [[ $TAG == "develop" ]]; then sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env; fi &&
-    sed -i "s/-vv/-v/" enigma-core/start_core.bash &&
-    popd
+    if [[ ${TRAVIS_BRANCH} == "master" ]]; then
+      export TAG=latest;
+      docker-compose pull
+    else
+      if ! (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CORE )); then
+        export TAG=develop;
+        sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
+        docker-compose pull
+      else
+        export TAG=$TRAVIS_BRANCH;
+        sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
+        if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
+          cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${TRAVIS_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+          docker pull enigmampc/enigma_contract:develop
+          docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+        else
+          if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
+            cd enigma-core
+            docker build --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$TAG --no-cache .
+            docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$TAG --no-cache .
+            cd ..
+            docker pull enigmampc/enigma_p2p:develop
+            docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$TAG
+          else
+            cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${TRAVIS_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+            cd enigma-core
+            docker build --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$TAG --no-cache .
+            docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${TRAVIS_BRANCH} --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$TAG --no-cache .
+            cd ..
+          fi
+        fi
+      fi
+    fi
+  - cd ..
   - pushd discovery-docker-network/enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=$TRAVIS_BRANCH -t enigmampc/enigma_contract:$TAG --no-cache . && popd
   - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
 

--- a/truffle.js
+++ b/truffle.js
@@ -24,12 +24,6 @@ module.exports = {
             host: "localhost",
             port: 30000,
             network_id: "3"
-        },
-        // This network section is needed for drone.io, do not remove
-        drone: {
-            host: 'ganache',
-            port: 9545,
-            network_id: '4447'
         }
     },
     solc: {

--- a/truffle.js
+++ b/truffle.js
@@ -24,6 +24,12 @@ module.exports = {
             host: "localhost",
             port: 30000,
             network_id: "3"
+        },
+        // This network section is needed for drone.io, do not remove
+        drone: {
+            host: 'ganache',
+            port: 9545,
+            network_id: '4447'
         }
     },
     solc: {


### PR DESCRIPTION
The CI now checks for matching branches across the other two repos, and conditionally builds against those other branches if a match is found. The logic is as follows:

1. If branch equals `master`, then use `latest` docker images
2. Else, if feature branch does NOT have a match in other repos, then use `develop` docker images
3. Else, if there is a match in only one other repo, then build a local image using that remote branch, AND reuse the existing `develop` for the repo there is no match (by tagging it as the one that will be used)
4. Else (there is a match on both repos), then build both local images.

Because of concurrency challenges derived from the fact that now three different repos `core`, `p2p` and `contract` handle the CI builds in the same host and they share docker resources, the images need to be separated between builds to avoid cross-contamination if there is a bogus image. Thus all images are tagged with `repo_build`, and deleted at the end of the build.


Analogous to:
- enigmampc/enigma-core#232
- enigmampc/enigma-p2p#236